### PR TITLE
fix .tree.panel li input:after padding

### DIFF
--- a/static/css/filetree/treestyles.css
+++ b/static/css/filetree/treestyles.css
@@ -59,7 +59,7 @@ ol.tree {
 
 .tree.panel li input:after{
     content:"";
-    padding: 20px;  
+    padding: 10px;  
     position: absolute;
     left: -10px;
     top: -10px;


### PR DESCRIPTION
Change padding 20px to 10px. 

input : after size is too large to click beside-plus and beside-cancel